### PR TITLE
[Feat] 프로젝트 초기 환경 구성 (Docker MySQL, 앱/테스트 설정)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testRuntimeOnly 'com.h2database:h2'
 	testCompileOnly 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testAnnotationProcessor 'org.projectlombok:lombok'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: dongho-product-engineer-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: localdev
+      MYSQL_DATABASE: productengineer
+      TZ: Asia/Seoul
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 15s
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+
+volumes:
+  mysql_data:
+    name: dongho-product-engineer-mysql-data

--- a/docs/epic-story-task.md
+++ b/docs/epic-story-task.md
@@ -22,21 +22,21 @@
 
 ### Story 1-1. Spring Boot 프로젝트 구성
 
-- [ ] **Task** `build.gradle` 의존성 추가
+- [x] **Task** `build.gradle` 의존성 추가
   - Spring Web, Spring Data JPA, MySQL Driver, Validation, Lombok
-- [ ] **Task** `application.yml` 환경 설정
+- [x] **Task** `application.yml` 환경 설정
   - DB 연결, JPA DDL 설정, 로깅 레벨
-- [ ] **Task** 레이어드 패키지 구조 설계
+- [x] **Task** 레이어드 패키지 구조 설계
   - Presentation, Business, Persistence 패키지 구조 설계
 
 ### Story 1-2. Docker Compose 환경 구성
 
-- [ ] **Task** `docker-compose.yml` 작성
+- [x] **Task** `docker-compose.yml` 작성
   - MySQL 컨테이너 설정 (이미지, 포트, 환경 변수)
   - 볼륨 마운트 설정 (데이터 영속성)
-- [ ] **Task** `application.yml` DB 연결 정보 연동
+- [x] **Task** `application.yml` DB 연결 정보 연동
   - `docker-compose.yml` 환경 변수와 일치하도록 설정
-- [ ] **Task** 로컬 실행 검증
+- [x] **Task** 로컬 실행 검증
   - `docker compose up` 후 애플리케이션 정상 기동 확인
 
 ### Story 1-3. 공통 컴포넌트 구성

--- a/src/main/java/io/github/jangdongho/productengineer/business/package-info.java
+++ b/src/main/java/io/github/jangdongho/productengineer/business/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * 애플리케이션 서비스, 도메인 로직, 유스케이스 (Business 계층)
+ */
+@org.springframework.lang.NonNullApi
+package io.github.jangdongho.productengineer.business;

--- a/src/main/java/io/github/jangdongho/productengineer/persistence/package-info.java
+++ b/src/main/java/io/github/jangdongho/productengineer/persistence/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * JPA 엔티티, 리포지토리, DB 접근 (Persistence / Infrastructure 계층)
+ */
+@org.springframework.lang.NonNullApi
+package io.github.jangdongho.productengineer.persistence;

--- a/src/main/java/io/github/jangdongho/productengineer/presentation/package-info.java
+++ b/src/main/java/io/github/jangdongho/productengineer/presentation/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * HTTP API, DTO, 요청·응답 매핑 (Presentation / Web 계층)
+ */
+@org.springframework.lang.NonNullApi
+package io.github.jangdongho.productengineer.presentation;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,30 @@
+# 로컬: docker compose MySQL . 기본값은 compose 환경 변수(MYSQL_*)와 동일한 자격 증명에 맞춤
+spring:
+  application:
+    name: dongho-product-engineer-be-a
+  datasource:
+    # DB 이름·비밀번호는 docker-compose의 MYSQL_DATABASE, MYSQL_ROOT_PASSWORD와 동일
+    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/productengineer?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
+    username: ${SPRING_DATASOURCE_USERNAME:root}
+    password: ${SPRING_DATASOURCE_PASSWORD:localdev}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+    database-platform: org.hibernate.dialect.MySQLDialect
+
+logging:
+  level:
+    root: INFO
+    org.springframework.web: INFO
+    org.hibernate.SQL: DEBUG
+    org.hibernate.orm.jdbc.bind: TRACE
+    io.github.jangdongho.productengineer: DEBUG
+
+server:
+  port: 8080

--- a/src/test/java/io/github/jangdongho/productengineer/DonghoProductEngineerBeAApplicationTests.java
+++ b/src/test/java/io/github/jangdongho/productengineer/DonghoProductEngineerBeAApplicationTests.java
@@ -2,8 +2,10 @@ package io.github.jangdongho.productengineer;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class DonghoProductEngineerBeAApplicationTests {
 
 	@Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,16 @@
+# 단위/통합 테스트: 별도 DB 없이 H2 in-memory
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false
+    username: sa
+    password: ""
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+    database-platform: org.hibernate.dialect.H2Dialect
+
+logging:
+  level:
+    org.hibernate.SQL: WARN


### PR DESCRIPTION
## 📌 개요

로컬 DB·앱 설정·테스트 환경을 갖춘 프로젝트 초기 구성

## ✨ 작업 내용

* `docker-compose.yml`로 로컬 MySQL 8.0 실행
* `application.yml` — MySQL 연동, JPA, 로깅
* `application-test.yml` + H2 인메모리(테스트 전용)
* `testRuntimeOnly` H2 의존성
* `business` / `persistence` / `presentation` 패키지 구조(`package-info`)
* `@ActiveProfiles("test")`로 통합 테스트 컨텍스트 로드
* `docs/epic-story-task.md` 문서 보완

## 🔥 변경 이유

* 로컬·개발은 MySQL, 테스트는 별도 DB 설치 없이 H2로 돌리기 위해

## 🧪 테스트

* [x] `docker compose up` 후 앱 기동·DB 연결 수동 확인

## 🔗 관련 이슈

* close #1
* close #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * MySQL 데이터베이스 로컬 개발 환경을 위한 Docker Compose 설정 추가
  * Spring Boot 애플리케이션 기본 구성 및 MySQL 연동 설정 완료

* **테스트**
  * H2 인메모리 데이터베이스를 활용한 테스트 환경 구성 추가
  * 테스트 프로필 기반 별도 설정 파일 추가

* **문서**
  * 계층별 패키지 문서화 및 아키텍처 설명 추가
  * 작업 완료 상태 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->