### PR TITLE
[Feat] 공통 예외 처리 및 API 응답 구조 추가

### DIFF
--- a/src/main/java/io/github/jangdongho/productengineer/common/api/ApiResponse.java
+++ b/src/main/java/io/github/jangdongho/productengineer/common/api/ApiResponse.java
@@ -1,0 +1,10 @@
+package io.github.jangdongho.productengineer.common.api;
+
+import org.springframework.lang.Nullable;
+
+public record ApiResponse<T>(boolean success, @Nullable T data) {
+
+	public static <T> ApiResponse<T> success(T data) {
+		return new ApiResponse<>(true, data);
+	}
+}

--- a/src/main/java/io/github/jangdongho/productengineer/common/api/ErrorResponse.java
+++ b/src/main/java/io/github/jangdongho/productengineer/common/api/ErrorResponse.java
@@ -1,0 +1,4 @@
+package io.github.jangdongho.productengineer.common.api;
+
+public record ErrorResponse(String code, String message) {
+}

--- a/src/main/java/io/github/jangdongho/productengineer/common/api/package-info.java
+++ b/src/main/java/io/github/jangdongho/productengineer/common/api/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * 공통 API 응답·에러 DTO
+ */
+@org.springframework.lang.NonNullApi
+package io.github.jangdongho.productengineer.common.api;

--- a/src/main/java/io/github/jangdongho/productengineer/common/exception/BusinessException.java
+++ b/src/main/java/io/github/jangdongho/productengineer/common/exception/BusinessException.java
@@ -1,0 +1,26 @@
+package io.github.jangdongho.productengineer.common.exception;
+
+import org.springframework.lang.Nullable;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public BusinessException(ErrorCode errorCode) {
+		super(errorCode.getDefaultMessage());
+		this.errorCode = errorCode;
+	}
+
+	public BusinessException(ErrorCode errorCode, @Nullable String message) {
+		super(message != null ? message : errorCode.getDefaultMessage());
+		this.errorCode = errorCode;
+	}
+
+	public BusinessException(ErrorCode errorCode, @Nullable String message, @Nullable Throwable cause) {
+		super(message != null ? message : errorCode.getDefaultMessage(), cause);
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/io/github/jangdongho/productengineer/common/exception/ErrorCode.java
+++ b/src/main/java/io/github/jangdongho/productengineer/common/exception/ErrorCode.java
@@ -1,0 +1,21 @@
+package io.github.jangdongho.productengineer.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+	VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "입력 값이 올바르지 않습니다."),
+
+	NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND", "리소스를 찾을 수 없습니다."),
+
+	INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.");
+
+	private final HttpStatus status;
+	private final String code;
+	private final String defaultMessage;
+}

--- a/src/main/java/io/github/jangdongho/productengineer/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/github/jangdongho/productengineer/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,53 @@
+package io.github.jangdongho.productengineer.common.exception;
+
+import java.util.stream.Collectors;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import io.github.jangdongho.productengineer.common.api.ErrorResponse;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(BusinessException.class)
+	public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+		ErrorCode errorCode = e.getErrorCode();
+		ErrorResponse body = new ErrorResponse(errorCode.getCode(), e.getMessage());
+		return ResponseEntity.status(errorCode.getStatus()).body(body);
+	}
+
+	@ExceptionHandler(SystemException.class)
+	public ResponseEntity<ErrorResponse> handleSystemException(SystemException e) {
+		log.error("SystemException", e);
+		ErrorCode errorCode = ErrorCode.INTERNAL_ERROR;
+		ErrorResponse body = new ErrorResponse(errorCode.getCode(), errorCode.getDefaultMessage());
+		return ResponseEntity.status(errorCode.getStatus()).body(body);
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+		String message = e.getBindingResult().getFieldErrors().stream()
+				.map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+				.collect(Collectors.joining(", "));
+		if (message.isEmpty()) {
+			message = ErrorCode.VALIDATION_ERROR.getDefaultMessage();
+		}
+		ErrorCode errorCode = ErrorCode.VALIDATION_ERROR;
+		ErrorResponse body = new ErrorResponse(errorCode.getCode(), message);
+		return ResponseEntity.status(errorCode.getStatus()).body(body);
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorResponse> handleException(Exception e) {
+		log.error("Unhandled exception", e);
+		ErrorCode errorCode = ErrorCode.INTERNAL_ERROR;
+		ErrorResponse body = new ErrorResponse(errorCode.getCode(), errorCode.getDefaultMessage());
+		return ResponseEntity.status(errorCode.getStatus()).body(body);
+	}
+}

--- a/src/main/java/io/github/jangdongho/productengineer/common/exception/SystemException.java
+++ b/src/main/java/io/github/jangdongho/productengineer/common/exception/SystemException.java
@@ -1,0 +1,14 @@
+package io.github.jangdongho.productengineer.common.exception;
+
+import org.springframework.lang.Nullable;
+
+public class SystemException extends RuntimeException {
+
+	public SystemException(String message) {
+		super(message);
+	}
+
+	public SystemException(String message, @Nullable Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/src/main/java/io/github/jangdongho/productengineer/common/exception/package-info.java
+++ b/src/main/java/io/github/jangdongho/productengineer/common/exception/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * ErrorCode, 커스텀 예외, 글로벌 예외 핸들러
+ */
+@org.springframework.lang.NonNullApi
+package io.github.jangdongho.productengineer.common.exception;

--- a/src/main/java/io/github/jangdongho/productengineer/common/package-info.java
+++ b/src/main/java/io/github/jangdongho/productengineer/common/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * 공통 DTO, 예외, 횡단 관심사 (API 응답/에러, 글로벌 핸들러 등)
+ */
+@org.springframework.lang.NonNullApi
+package io.github.jangdongho.productengineer.common;

--- a/src/test/java/io/github/jangdongho/productengineer/common/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/io/github/jangdongho/productengineer/common/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,62 @@
+package io.github.jangdongho.productengineer.common.exception;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = TestExceptionController.class)
+@Import(GlobalExceptionHandler.class)
+@ActiveProfiles("test")
+class GlobalExceptionHandlerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("BusinessException 응답에 code, message와 HTTP 상태가 ErrorCode와 일치한다")
+	void businessException_returnsCodeMessageAndStatus() throws Exception {
+		mockMvc.perform(get("/__test/business"))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code", is("NOT_FOUND")))
+				.andExpect(jsonPath("$.message", is("custom not found")));
+	}
+
+	@Test
+	@DisplayName("SystemException 은 500과 INTERNAL_ERROR code, 일반화된 message 를 반환한다")
+	void systemException_returnsInternalError() throws Exception {
+		mockMvc.perform(get("/__test/system"))
+				.andExpect(status().isInternalServerError())
+				.andExpect(jsonPath("$.code", is("INTERNAL_ERROR")))
+				.andExpect(jsonPath("$.message", is(ErrorCode.INTERNAL_ERROR.getDefaultMessage())));
+	}
+
+	@Test
+	@DisplayName("MethodArgumentNotValidException 은 400과 VALIDATION_ERROR code 를 반환한다")
+	void validation_returnsValidationError() throws Exception {
+		mockMvc.perform(post("/__test/validate")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content("{}"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code", is("VALIDATION_ERROR")));
+	}
+
+	@Test
+	@DisplayName("예상치 못한 예외는 500과 INTERNAL_ERROR 를 반환한다")
+	void unexpectedException_returnsInternalError() throws Exception {
+		mockMvc.perform(get("/__test/unexpected"))
+				.andExpect(status().isInternalServerError())
+				.andExpect(jsonPath("$.code", is("INTERNAL_ERROR")))
+				.andExpect(jsonPath("$.message", is(ErrorCode.INTERNAL_ERROR.getDefaultMessage())));
+	}
+}

--- a/src/test/java/io/github/jangdongho/productengineer/common/exception/TestExceptionController.java
+++ b/src/test/java/io/github/jangdongho/productengineer/common/exception/TestExceptionController.java
@@ -1,0 +1,38 @@
+package io.github.jangdongho.productengineer.common.exception;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+
+@RestController
+@RequestMapping("/__test")
+public class TestExceptionController {
+
+	@GetMapping("/business")
+	public void business() {
+		throw new BusinessException(ErrorCode.NOT_FOUND, "custom not found");
+	}
+
+	@GetMapping("/system")
+	public void system() {
+		throw new SystemException("internal detail");
+	}
+
+	@GetMapping("/unexpected")
+	public void unexpected() {
+		throw new IllegalStateException("unexpected");
+	}
+
+	@PostMapping("/validate")
+	public void validate(@Valid @RequestBody TestRequest request) {
+		// validated only
+	}
+
+	public record TestRequest(@NotBlank String name) {
+	}
+}


### PR DESCRIPTION
## 📌 개요

- 공통 예외·응답 DTO·전역 예외 처리를 도입해 API 에러 포맷을 `{ code, message }`로 통일했습니다.

## ✨ 작업 내용

- `ErrorCode`와 `BusinessException` / `SystemException`으로 실패 유형 분리
- `ErrorResponse`, `ApiResponse<T>` 추가
- `GlobalExceptionHandler`(`@RestControllerAdvice`)에서 예외 유형별로 `ErrorResponse` + HTTP 상태로 변환
  - `BusinessException` → `ErrorCode`에 따른 HTTP 상태, 응답 `code`/`message`는 enum 코드와 `getMessage()` 기준
  - `SystemException` → 500, 응답은 `INTERNAL_ERROR`와 기본(일반화) 메시지, 상세는 서버 로그
  - `MethodArgumentNotValidException`(`@Valid` 실패) → 400, `VALIDATION_ERROR`와 필드 오류 요약 `message`
  - 그 외 `Exception` → 500, `INTERNAL_ERROR`와 기본 메시지(미처리 오류)

## 🔥 변경 이유

- 이후 강의/수강 API 추가 시에도 동일한 에러 계약을 유지하고, 예외 분기·로깅(시스템 실패)과 클라이언트 메시지(비즈니스 실패)를 나누기 위함입니다.

## 🧪 테스트

- [x] 정상: `./gradlew test` 전체 통과
- [x] 예외: `GlobalExceptionHandlerTest` 커버(비즈니스 / 시스템 / validation / unhandled)

## 🔗 관련 이슈

- close #4