### PR TITLE
[Feat] 강의별 확정 수강생 목록 조회 기능 추가

### DIFF
--- a/docs/epic-story-task.md
+++ b/docs/epic-story-task.md
@@ -203,15 +203,15 @@
 
 ### Story 5-1. 강의별 수강생 목록 조회 (크리에이터 전용)
 
-- [ ] **Task** `GET /classes/{id}/enrollments` API 구현
+- [x] **Task** `GET /classes/{id}/enrollments` API 구현
   - `CONFIRMED` 상태 수강생만 반환
-- [ ] **Task** 크리에이터 소유권 검증
+- [x] **Task** 크리에이터 소유권 검증
   - 요청한 `creatorId`가 강의 소유자인지 확인 → 아니면 403 Forbidden
-- [ ] **Task** 단위 테스트 작성
+- [x] **Task** 단위 테스트 작성
 
 ### Story 5-2. 신청 내역 페이지네이션
 
-- [ ] **Task** 내 수강 신청 목록 API에 페이지네이션 적용
+- [ ] **Task** 페이지네이션 적용 (내 수강 신청 목록, 강의 목록 조회, 강의별 확정 수강생 목록 API)
   - Cursor 기반 또는 Offset 기반 결정
   - Query Param: `page`, `size` (또는 `cursor`, `size`)
 

--- a/src/main/java/io/github/jangdongho/productengineer/common/exception/ErrorCode.java
+++ b/src/main/java/io/github/jangdongho/productengineer/common/exception/ErrorCode.java
@@ -13,6 +13,8 @@ public enum ErrorCode {
 
 	NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND", "리소스를 찾을 수 없습니다."),
 
+	FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "이 리소스에 접근할 권한이 없습니다."),
+
 	CONFLICT(HttpStatus.CONFLICT, "CONFLICT", "요청이 현재 리소스 상태와 충돌합니다."),
 
 	INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.");

--- a/src/main/java/io/github/jangdongho/productengineer/enrollment/dto/ClassConfirmedEnrollmentItemResponse.java
+++ b/src/main/java/io/github/jangdongho/productengineer/enrollment/dto/ClassConfirmedEnrollmentItemResponse.java
@@ -1,0 +1,20 @@
+package io.github.jangdongho.productengineer.enrollment.dto;
+
+import io.github.jangdongho.productengineer.enrollment.domain.EnrollmentStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "강의별 확정 수강생 목록 항목 (크리에이터 조회용, CONFIRMED만)")
+public record ClassConfirmedEnrollmentItemResponse(
+		@Schema(description = "수강 신청 ID", example = "1")
+		long enrollmentId,
+
+		@Schema(description = "수강생 사용자 ID", example = "42")
+		long userId,
+
+		@Schema(description = "수강 신청 상태", example = "CONFIRMED")
+		EnrollmentStatus status,
+
+		@Schema(description = "결제 확정 시각", example = "2026-05-01T12:00:00")
+		LocalDateTime confirmedAt) {
+}

--- a/src/main/java/io/github/jangdongho/productengineer/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/io/github/jangdongho/productengineer/enrollment/repository/EnrollmentRepository.java
@@ -4,10 +4,13 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import io.github.jangdongho.productengineer.enrollment.domain.Enrollment;
+import io.github.jangdongho.productengineer.enrollment.domain.EnrollmentStatus;
 
 public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
 
 	boolean existsByUserIdAndClassId(Long userId, Long classId);
 
 	List<Enrollment> findByUserIdOrderByCreatedAtDescIdDesc(Long userId);
+
+	List<Enrollment> findByClassIdAndStatusOrderByCreatedAtDescIdDesc(Long classId, EnrollmentStatus status);
 }

--- a/src/main/java/io/github/jangdongho/productengineer/lecture/controller/ClassController.java
+++ b/src/main/java/io/github/jangdongho/productengineer/lecture/controller/ClassController.java
@@ -9,6 +9,7 @@ import io.github.jangdongho.productengineer.lecture.dto.ClassListItemResponse;
 import io.github.jangdongho.productengineer.lecture.dto.ClassStatusResponse;
 import io.github.jangdongho.productengineer.lecture.dto.CreateClassRequest;
 import io.github.jangdongho.productengineer.lecture.dto.UpdateClassStatusRequest;
+import io.github.jangdongho.productengineer.enrollment.dto.ClassConfirmedEnrollmentItemResponse;
 import io.github.jangdongho.productengineer.lecture.service.LectureService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -121,6 +122,58 @@ public class ClassController {
 			@Parameter(description = "강의 ID", example = "1")
 			@PathVariable long id) {
 		return ResponseEntity.ok(ApiResponse.success(lectureService.getClassById(id)));
+	}
+
+	@Operation(
+			summary = "강의별 확정 수강생 목록",
+			description = "강의 소유자(creatorId)가 해당 강의의 CONFIRMED 수강 신청만 조회합니다. 강의가 없으면 404, 소유자가 아니면 403입니다."
+	)
+	@ApiResponses({
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "200",
+					description = "조회 성공 (확정 수강생 없으면 빈 배열)",
+					content = @Content(
+							mediaType = "application/json",
+							schema = @Schema(implementation = ApiResponse.class),
+							examples = @ExampleObject(value = """
+									{
+									  "success": true,
+									  "data": [
+									    {
+									      "enrollmentId": 1,
+									      "userId": 100,
+									      "status": "CONFIRMED",
+									      "confirmedAt": "2026-05-01T12:00:00"
+									    }
+									  ]
+									}
+									""")
+					)
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "400",
+					description = "creatorId 누락 또는 유효하지 않은 값",
+					content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "403",
+					description = "강의 소유자가 아님",
+					content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+			),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(
+					responseCode = "404",
+					description = "강의를 찾을 수 없음",
+					content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+			)
+	})
+	@GetMapping("/{id}/enrollments")
+	public ResponseEntity<ApiResponse<List<ClassConfirmedEnrollmentItemResponse>>> listConfirmedEnrollments(
+			@Parameter(description = "강의 ID", example = "1")
+			@PathVariable long id,
+			@Parameter(description = "강의 소유자(크리에이터) ID", example = "10", required = true)
+			@RequestParam("creatorId") @NotNull @Positive Long creatorId) {
+		return ResponseEntity.ok(
+				ApiResponse.success(lectureService.listConfirmedEnrollmentsForCreator(id, creatorId)));
 	}
 
 	@Operation(summary = "강의 생성", description = "크리에이터 ID와 강의 정보를 받아 강의를 DRAFT 상태로 생성합니다.")

--- a/src/main/java/io/github/jangdongho/productengineer/lecture/service/LectureService.java
+++ b/src/main/java/io/github/jangdongho/productengineer/lecture/service/LectureService.java
@@ -2,6 +2,10 @@ package io.github.jangdongho.productengineer.lecture.service;
 
 import io.github.jangdongho.productengineer.common.exception.BusinessException;
 import io.github.jangdongho.productengineer.common.exception.ErrorCode;
+import io.github.jangdongho.productengineer.enrollment.domain.Enrollment;
+import io.github.jangdongho.productengineer.enrollment.domain.EnrollmentStatus;
+import io.github.jangdongho.productengineer.enrollment.dto.ClassConfirmedEnrollmentItemResponse;
+import io.github.jangdongho.productengineer.enrollment.repository.EnrollmentRepository;
 import io.github.jangdongho.productengineer.lecture.domain.ClassStatus;
 import io.github.jangdongho.productengineer.lecture.domain.Lecture;
 import io.github.jangdongho.productengineer.lecture.dto.ClassCreatedResponse;
@@ -12,6 +16,7 @@ import io.github.jangdongho.productengineer.lecture.dto.CreateClassRequest;
 import io.github.jangdongho.productengineer.lecture.repository.LectureRepository;
 
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
@@ -22,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class LectureService {
 
 	private final LectureRepository lectureRepository;
+	private final EnrollmentRepository enrollmentRepository;
 
 	@Transactional(readOnly = true)
 	public List<ClassListItemResponse> listClasses(@Nullable ClassStatus status) {
@@ -36,6 +42,22 @@ public class LectureService {
 		Lecture lecture = lectureRepository.findById(id)
 				.orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
 		return toDetail(lecture);
+	}
+
+	@Transactional(readOnly = true)
+	public List<ClassConfirmedEnrollmentItemResponse> listConfirmedEnrollmentsForCreator(long classId, long creatorId) {
+		Lecture lecture = lectureRepository.findById(classId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+		if (!Objects.equals(lecture.getCreatorId(), creatorId)) {
+			throw new BusinessException(ErrorCode.FORBIDDEN);
+		}
+		
+		return enrollmentRepository
+				.findByClassIdAndStatusOrderByCreatedAtDescIdDesc(classId, EnrollmentStatus.CONFIRMED)
+				.stream()
+				.map(this::toClassConfirmedItem)
+				.toList();
 	}
 
 	@Transactional
@@ -102,5 +124,13 @@ public class LectureService {
 				lecture.getCurrentEnrollment(),
 				lecture.getStartDate(),
 				lecture.getEndDate());
+	}
+
+	private ClassConfirmedEnrollmentItemResponse toClassConfirmedItem(Enrollment e) {
+		return new ClassConfirmedEnrollmentItemResponse(
+				e.getId(),
+				e.getUserId(),
+				e.getStatus(),
+				e.getConfirmedAt());
 	}
 }

--- a/src/test/java/io/github/jangdongho/productengineer/lecture/controller/ClassControllerTest.java
+++ b/src/test/java/io/github/jangdongho/productengineer/lecture/controller/ClassControllerTest.java
@@ -14,6 +14,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import io.github.jangdongho.productengineer.common.exception.BusinessException;
 import io.github.jangdongho.productengineer.common.exception.ErrorCode;
 import io.github.jangdongho.productengineer.common.exception.GlobalExceptionHandler;
+import io.github.jangdongho.productengineer.enrollment.domain.EnrollmentStatus;
+import io.github.jangdongho.productengineer.enrollment.dto.ClassConfirmedEnrollmentItemResponse;
 import io.github.jangdongho.productengineer.lecture.domain.ClassStatus;
 import io.github.jangdongho.productengineer.lecture.dto.ClassCreatedResponse;
 import io.github.jangdongho.productengineer.lecture.dto.ClassDetailResponse;
@@ -96,6 +98,71 @@ class ClassControllerTest {
 		mockMvc.perform(get("/classes/99"))
 				.andExpect(status().isNotFound())
 				.andExpect(jsonPath("$.code", is(ErrorCode.NOT_FOUND.getCode())));
+	}
+
+	@Test
+	@DisplayName("GET /classes/{id}/enrollments?creatorId= 는 소유자·확정 수강생을 반환한다")
+	void getEnrollments_confirmedList_returns200() throws Exception {
+		ClassConfirmedEnrollmentItemResponse row = new ClassConfirmedEnrollmentItemResponse(
+				1L, 100L, EnrollmentStatus.CONFIRMED, LocalDateTime.parse("2026-05-01T12:00:00"));
+		when(lectureService.listConfirmedEnrollmentsForCreator(1L, 10L)).thenReturn(List.of(row));
+
+		mockMvc.perform(get("/classes/1/enrollments").param("creatorId", "10"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success", is(true)))
+				.andExpect(jsonPath("$.data[0].enrollmentId", is(1)))
+				.andExpect(jsonPath("$.data[0].userId", is(100)))
+				.andExpect(jsonPath("$.data[0].status", is("CONFIRMED")));
+		verify(lectureService).listConfirmedEnrollmentsForCreator(1L, 10L);
+	}
+
+	@Test
+	@DisplayName("GET /classes/{id}/enrollments 는 확정 수강생 없을 때 200 빈 배열")
+	void getEnrollments_empty_returns200() throws Exception {
+		when(lectureService.listConfirmedEnrollmentsForCreator(2L, 1L)).thenReturn(List.of());
+
+		mockMvc.perform(get("/classes/2/enrollments").param("creatorId", "1"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success", is(true)))
+				.andExpect(jsonPath("$.data.length()", is(0)));
+	}
+
+	@Test
+	@DisplayName("GET /classes/{id}/enrollments 는 강의 없을 때 404")
+	void getEnrollments_notFound_returns404() throws Exception {
+		when(lectureService.listConfirmedEnrollmentsForCreator(99L, 1L))
+				.thenThrow(new BusinessException(ErrorCode.NOT_FOUND));
+
+		mockMvc.perform(get("/classes/99/enrollments").param("creatorId", "1"))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.code", is(ErrorCode.NOT_FOUND.getCode())));
+	}
+
+	@Test
+	@DisplayName("GET /classes/{id}/enrollments 는 비소유자 403")
+	void getEnrollments_forbidden_returns403() throws Exception {
+		when(lectureService.listConfirmedEnrollmentsForCreator(1L, 2L))
+				.thenThrow(new BusinessException(ErrorCode.FORBIDDEN));
+
+		mockMvc.perform(get("/classes/1/enrollments").param("creatorId", "2"))
+				.andExpect(status().isForbidden())
+				.andExpect(jsonPath("$.code", is(ErrorCode.FORBIDDEN.getCode())));
+	}
+
+	@Test
+	@DisplayName("GET /classes/{id}/enrollments 는 creatorId 누락 시 400")
+	void getEnrollments_missingCreatorId_returns400() throws Exception {
+		mockMvc.perform(get("/classes/1/enrollments"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code", is(ErrorCode.VALIDATION_ERROR.getCode())));
+	}
+
+	@Test
+	@DisplayName("GET /classes/{id}/enrollments 는 creatorId 가 음수면 400")
+	void getEnrollments_invalidCreatorId_returns400() throws Exception {
+		mockMvc.perform(get("/classes/1/enrollments").param("creatorId", "-1"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code", is(ErrorCode.VALIDATION_ERROR.getCode())));
 	}
 
 	@Test

--- a/src/test/java/io/github/jangdongho/productengineer/lecture/service/LectureServiceTest.java
+++ b/src/test/java/io/github/jangdongho/productengineer/lecture/service/LectureServiceTest.java
@@ -4,11 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.github.jangdongho.productengineer.common.exception.BusinessException;
 import io.github.jangdongho.productengineer.common.exception.ErrorCode;
+import io.github.jangdongho.productengineer.enrollment.domain.Enrollment;
+import io.github.jangdongho.productengineer.enrollment.domain.EnrollmentStatus;
+import io.github.jangdongho.productengineer.enrollment.dto.ClassConfirmedEnrollmentItemResponse;
+import io.github.jangdongho.productengineer.enrollment.repository.EnrollmentRepository;
 import io.github.jangdongho.productengineer.lecture.domain.ClassStatus;
 import io.github.jangdongho.productengineer.lecture.domain.Lecture;
 import io.github.jangdongho.productengineer.lecture.dto.ClassDetailResponse;
@@ -31,6 +36,9 @@ class LectureServiceTest {
 
 	@Mock
 	private LectureRepository lectureRepository;
+
+	@Mock
+	private EnrollmentRepository enrollmentRepository;
 
 	@InjectMocks
 	private LectureService lectureService;
@@ -126,6 +134,7 @@ class LectureServiceTest {
 
 		verify(lectureRepository).findById(eq(1L));
 		verifyNoMoreInteractions(lectureRepository);
+		verifyNoInteractions(enrollmentRepository);
 	}
 
 	@Test
@@ -148,6 +157,70 @@ class LectureServiceTest {
 		assertThatThrownBy(() -> lectureService.updateStatus(99L, ClassStatus.OPEN))
 				.isInstanceOf(BusinessException.class)
 				.satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND));
+	}
+
+	@Test
+	@DisplayName("listConfirmedEnrollmentsForCreator: 강의 없으면 NOT_FOUND, enrollmentRepository 미호출")
+	void listConfirmed_classNotFound() {
+		when(lectureRepository.findById(99L)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> lectureService.listConfirmedEnrollmentsForCreator(99L, 1L))
+				.isInstanceOf(BusinessException.class)
+				.satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND));
+
+		verifyNoInteractions(enrollmentRepository);
+	}
+
+	@Test
+	@DisplayName("listConfirmedEnrollmentsForCreator: 소유자 아님 FORBIDDEN, enrollmentRepository 미호출")
+	void listConfirmed_forbidden() {
+		Lecture lecture = sampleLecture(1L, ClassStatus.OPEN);
+		lecture.setCreatorId(10L);
+		when(lectureRepository.findById(1L)).thenReturn(Optional.of(lecture));
+
+		assertThatThrownBy(() -> lectureService.listConfirmedEnrollmentsForCreator(1L, 99L))
+				.isInstanceOf(BusinessException.class)
+				.satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode()).isEqualTo(ErrorCode.FORBIDDEN));
+
+		verifyNoInteractions(enrollmentRepository);
+	}
+
+	@Test
+	@DisplayName("listConfirmedEnrollmentsForCreator: 소유자·CONFIRMED 없으면 빈 목록")
+	void listConfirmed_empty() {
+		Lecture lecture = sampleLecture(5L, ClassStatus.OPEN);
+		lecture.setCreatorId(2L);
+		when(lectureRepository.findById(5L)).thenReturn(Optional.of(lecture));
+		when(enrollmentRepository.findByClassIdAndStatusOrderByCreatedAtDescIdDesc(5L, EnrollmentStatus.CONFIRMED))
+				.thenReturn(List.of());
+
+		List<ClassConfirmedEnrollmentItemResponse> result = lectureService.listConfirmedEnrollmentsForCreator(5L, 2L);
+
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("listConfirmedEnrollmentsForCreator: CONFIRMED 항목을 DTO로 반환")
+	void listConfirmed_mapsRows() {
+		Lecture lecture = sampleLecture(3L, ClassStatus.OPEN);
+		lecture.setCreatorId(7L);
+		Enrollment e = new Enrollment();
+		e.setId(100L);
+		e.setUserId(20L);
+		e.setClassId(3L);
+		e.setStatus(EnrollmentStatus.CONFIRMED);
+		e.setConfirmedAt(LocalDateTime.parse("2026-06-10T15:00:00"));
+		when(lectureRepository.findById(3L)).thenReturn(Optional.of(lecture));
+		when(enrollmentRepository.findByClassIdAndStatusOrderByCreatedAtDescIdDesc(3L, EnrollmentStatus.CONFIRMED))
+				.thenReturn(List.of(e));
+
+		List<ClassConfirmedEnrollmentItemResponse> result = lectureService.listConfirmedEnrollmentsForCreator(3L, 7L);
+
+		assertThat(result).hasSize(1);
+		assertThat(result.getFirst().enrollmentId()).isEqualTo(100L);
+		assertThat(result.getFirst().userId()).isEqualTo(20L);
+		assertThat(result.getFirst().status()).isEqualTo(EnrollmentStatus.CONFIRMED);
+		assertThat(result.getFirst().confirmedAt()).isEqualTo(LocalDateTime.parse("2026-06-10T15:00:00"));
 	}
 
 	private static Lecture sampleLecture(long id, ClassStatus status) {


### PR DESCRIPTION
## 📌 개요

- 크리에이터가 본인 강의의 확정 수강생 목록을 조회할 수 있는 API를 추가했습니다.

## ✨ 작업 내용

- `GET /classes/{id}/enrollments?creatorId={creatorId}` API 추가
- 강의 존재 여부를 먼저 확인하고, 요청한 `creatorId`가 강의 소유자가 아니면 `403 Forbidden`을 반환하도록 검증
- 수강 신청 중 `CONFIRMED` 상태만 최신순으로 조회해 `enrollmentId`, `userId`, `status`, `confirmedAt`을 반환
- 접근 권한 오류를 표현하기 위한 `FORBIDDEN` 에러 코드 추가
- Swagger 문서에 성공/검증 실패/권한 없음/강의 없음 응답 케이스 반영

## 🔥 변경 이유 (선택)

- 크리에이터가 강의 운영 관점에서 실제 확정된 수강생만 확인할 수 있도록, 신청 상태와 강의 소유권을 함께 검증하는 전용 조회 흐름이 필요했습니다.

## 🧪 테스트

- [x] 정상 조회 (200)
- [x] 확정 수강생 없음 (200 + 빈 배열)
- [x] 강의 없음 (404)
- [x] 비소유자 접근 (403)
- [x] `creatorId` 누락/음수 검증 (400)

## 🔗 관련 이슈

- close #19 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 클래스별 확인된 등록 현황 조회 API 추가
  * 강사 전용 접근 제어 및 권한 검증 기능 구현

* **Documentation**
  * 작업 완료 항목 업데이트 및 스토리 범위 명확화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->