### PR TITLE
[Feat] 목록 조회 API 페이지네이션 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,43 @@
 | ------- | --------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------- | ----------- |
 | `POST`  | `/classes`                  | 강의 등록                            | `title`, `description`, `price`, `capacity`, `startDate`, `endDate` (`price` 는 KRW **원** 단위 정수) | 201 Created |
 | `PATCH` | `/classes/{id}/status`      | 강의 상태 전이                       | `status` (`DRAFT` \| `OPEN` \| `CLOSED`)                                                              | 200 OK      |
-| `GET`   | `/classes`                  | 강의 목록 조회                       | Query: `status` (선택)                                                                                | 200 OK      |
+| `GET`   | `/classes`                  | 강의 목록 조회                       | Query: `status` (선택), `page`, `size`                                                                | 200 OK      |
 | `GET`   | `/classes/{id}`             | 강의 상세 조회                       | —                                                                                                     | 200 OK      |
-| `GET`   | `/classes/{id}/enrollments` | 강의별 수강생 목록 (크리에이터 전용) | Query: `creatorId`                                                                                    | 200 OK      |
+| `GET`   | `/classes/{id}/enrollments` | 강의별 수강생 목록 (크리에이터 전용) | Query: `creatorId`, `page`, `size`                                                                    | 200 OK      |
+
+#### 목록 조회 페이지네이션
+
+- Offset 기반 페이지네이션을 사용합니다.
+- `page`는 0부터 시작하며 기본값은 `0`입니다.
+- `size`는 기본값 `20`, 최댓값 `100`입니다.
+- 페이지네이션이 적용된 목록 API는 응답 루트에서 `data`와 `meta`를 분리해 반환합니다.
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": 1,
+      "creatorId": 10,
+      "title": "Spring Boot 실전 클래스",
+      "status": "OPEN",
+      "price": 10000,
+      "capacity": 30,
+      "startDate": "2026-05-01T10:00:00",
+      "endDate": "2026-05-30T18:00:00"
+    }
+  ],
+  "meta": {
+    "page": 0,
+    "size": 20,
+    "totalElements": 42,
+    "totalPages": 3,
+    "hasNext": true,
+    "hasPrevious": false,
+    "nextPage": 1
+  }
+}
+```
 
 #### 강의 상태 전이 규칙
 

--- a/src/main/java/io/github/jangdongho/productengineer/common/api/ApiResponse.java
+++ b/src/main/java/io/github/jangdongho/productengineer/common/api/ApiResponse.java
@@ -1,5 +1,6 @@
 package io.github.jangdongho.productengineer.common.api;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.lang.Nullable;
 
@@ -10,10 +11,19 @@ public record ApiResponse<T>(
 
 		@Nullable
 		@Schema(description = "응답 데이터")
-		T data
+		T data,
+
+		@Nullable
+		@JsonInclude(JsonInclude.Include.NON_NULL)
+		@Schema(description = "응답 메타데이터")
+		Object meta
 ) {
 
 	public static <T> ApiResponse<T> success(T data) {
-		return new ApiResponse<>(true, data);
+		return new ApiResponse<>(true, data, null);
+	}
+
+	public static <T> ApiResponse<T> success(T data, Object meta) {
+		return new ApiResponse<>(true, data, meta);
 	}
 }

--- a/src/main/java/io/github/jangdongho/productengineer/common/api/PageMeta.java
+++ b/src/main/java/io/github/jangdongho/productengineer/common/api/PageMeta.java
@@ -1,0 +1,44 @@
+package io.github.jangdongho.productengineer.common.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Page;
+import org.springframework.lang.Nullable;
+
+@Schema(description = "페이지네이션 메타데이터")
+public record PageMeta(
+		@Schema(description = "현재 페이지 번호(0부터 시작)", example = "0")
+		int page,
+
+		@Schema(description = "페이지 크기", example = "20")
+		int size,
+
+		@Schema(description = "전체 건수", example = "42")
+		long totalElements,
+
+		@Schema(description = "전체 페이지 수", example = "3")
+		int totalPages,
+
+		@Schema(description = "다음 페이지 존재 여부", example = "true")
+		boolean hasNext,
+
+		@Schema(description = "이전 페이지 존재 여부", example = "false")
+		boolean hasPrevious,
+
+		@Nullable
+		@JsonInclude(JsonInclude.Include.NON_NULL)
+		@Schema(description = "다음 페이지 번호(없으면 null)", example = "1")
+		Integer nextPage
+) {
+
+	public static PageMeta from(Page<?> page) {
+		return new PageMeta(
+				page.getNumber(),
+				page.getSize(),
+				page.getTotalElements(),
+				page.getTotalPages(),
+				page.hasNext(),
+				page.hasPrevious(),
+				page.hasNext() ? page.getNumber() + 1 : null);
+	}
+}

--- a/src/main/java/io/github/jangdongho/productengineer/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/io/github/jangdongho/productengineer/enrollment/controller/EnrollmentController.java
@@ -2,6 +2,7 @@ package io.github.jangdongho.productengineer.enrollment.controller;
 
 import io.github.jangdongho.productengineer.common.api.ApiResponse;
 import io.github.jangdongho.productengineer.common.api.ErrorResponse;
+import io.github.jangdongho.productengineer.common.api.PageMeta;
 import io.github.jangdongho.productengineer.enrollment.dto.CreateEnrollmentRequest;
 import io.github.jangdongho.productengineer.enrollment.dto.EnrollmentCancelledResponse;
 import io.github.jangdongho.productengineer.enrollment.dto.EnrollmentConfirmedResponse;
@@ -16,10 +17,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -39,11 +44,15 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Enrollments", description = "수강 신청 API")
 public class EnrollmentController {
 
+	private static final int DEFAULT_PAGE = 0;
+	private static final int DEFAULT_SIZE = 20;
+	private static final int MAX_SIZE = 100;
+
 	private final EnrollmentService enrollmentService;
 
 	@Operation(
 			summary = "내 수강 신청 목록",
-			description = "특정 사용자의 수강 신청을 수강 신청 ID 오름차순으로 조회합니다. 각 항목에 강의 요약(강의 목록 항목과 동일)과 신청 상태가 포함됩니다.")
+			description = "특정 사용자의 수강 신청을 생성일 최신순으로 페이지 조회합니다. 각 항목에 강의 요약(강의 목록 항목과 동일)과 신청 상태가 포함됩니다.")
 	@ApiResponses({
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(
 					responseCode = "200",
@@ -70,7 +79,15 @@ public class EnrollmentController {
 									        "endDate": "2026-05-30T18:00:00"
 									      }
 									    }
-									  ]
+									  ],
+									  "meta": {
+									    "page": 0,
+									    "size": 20,
+									    "totalElements": 1,
+									    "totalPages": 1,
+									    "hasNext": false,
+									    "hasPrevious": false
+									  }
 									}
 									""")
 					)
@@ -89,8 +106,13 @@ public class EnrollmentController {
 	@GetMapping
 	public ResponseEntity<ApiResponse<List<EnrollmentListItemResponse>>> list(
 			@Parameter(description = "사용자 ID", example = "1", required = true)
-			@RequestParam("userId") @NotNull @Positive Long userId) {
-		return ResponseEntity.ok(ApiResponse.success(enrollmentService.listByUserId(userId)));
+			@RequestParam("userId") @NotNull @Positive Long userId,
+			@Parameter(description = "페이지 번호(0부터 시작)", example = "0")
+			@RequestParam(name = "page", defaultValue = "" + DEFAULT_PAGE) @PositiveOrZero int page,
+			@Parameter(description = "페이지 크기(1~100)", example = "20")
+			@RequestParam(name = "size", defaultValue = "" + DEFAULT_SIZE) @Positive @Max(MAX_SIZE) int size) {
+		Page<EnrollmentListItemResponse> response = enrollmentService.listByUserId(userId, PageRequest.of(page, size));
+		return ResponseEntity.ok(ApiResponse.success(response.getContent(), PageMeta.from(response)));
 	}
 
 	@Operation(summary = "수강 신청", description = "모집 중인 강의에 수강 신청을 등록합니다. 상태는 PENDING이며, 신청 시점에 정원(currentEnrollment)이 반영됩니다.")

--- a/src/main/java/io/github/jangdongho/productengineer/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/io/github/jangdongho/productengineer/enrollment/controller/EnrollmentController.java
@@ -46,6 +46,7 @@ public class EnrollmentController {
 
 	private static final int DEFAULT_PAGE = 0;
 	private static final int DEFAULT_SIZE = 20;
+	private static final int MAX_PAGE = 10_000;
 	private static final int MAX_SIZE = 100;
 
 	private final EnrollmentService enrollmentService;
@@ -107,8 +108,8 @@ public class EnrollmentController {
 	public ResponseEntity<ApiResponse<List<EnrollmentListItemResponse>>> list(
 			@Parameter(description = "사용자 ID", example = "1", required = true)
 			@RequestParam("userId") @NotNull @Positive Long userId,
-			@Parameter(description = "페이지 번호(0부터 시작)", example = "0")
-			@RequestParam(name = "page", defaultValue = "" + DEFAULT_PAGE) @PositiveOrZero int page,
+			@Parameter(description = "페이지 번호(0~10000)", example = "0")
+			@RequestParam(name = "page", defaultValue = "" + DEFAULT_PAGE) @PositiveOrZero @Max(MAX_PAGE) int page,
 			@Parameter(description = "페이지 크기(1~100)", example = "20")
 			@RequestParam(name = "size", defaultValue = "" + DEFAULT_SIZE) @Positive @Max(MAX_SIZE) int size) {
 		Page<EnrollmentListItemResponse> response = enrollmentService.listByUserId(userId, PageRequest.of(page, size));

--- a/src/main/java/io/github/jangdongho/productengineer/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/io/github/jangdongho/productengineer/enrollment/repository/EnrollmentRepository.java
@@ -1,6 +1,7 @@
 package io.github.jangdongho.productengineer.enrollment.repository;
 
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import io.github.jangdongho.productengineer.enrollment.domain.Enrollment;
@@ -10,7 +11,10 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
 
 	boolean existsByUserIdAndClassId(Long userId, Long classId);
 
-	List<Enrollment> findByUserIdOrderByCreatedAtDescIdDesc(Long userId);
+	Page<Enrollment> findByUserIdOrderByCreatedAtDescIdDesc(Long userId, Pageable pageable);
 
-	List<Enrollment> findByClassIdAndStatusOrderByCreatedAtDescIdDesc(Long classId, EnrollmentStatus status);
+	Page<Enrollment> findByClassIdAndStatusOrderByCreatedAtDescIdDesc(
+			Long classId,
+			EnrollmentStatus status,
+			Pageable pageable);
 }

--- a/src/main/java/io/github/jangdongho/productengineer/enrollment/service/EnrollmentService.java
+++ b/src/main/java/io/github/jangdongho/productengineer/enrollment/service/EnrollmentService.java
@@ -20,6 +20,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,31 +35,29 @@ public class EnrollmentService {
 	private final Clock clock;
 
 	@Transactional(readOnly = true)
-	public List<EnrollmentListItemResponse> listByUserId(long userId) {
-		List<Enrollment> enrollments = enrollmentRepository.findByUserIdOrderByCreatedAtDescIdDesc(userId);
+	public Page<EnrollmentListItemResponse> listByUserId(long userId, Pageable pageable) {
+		Page<Enrollment> enrollments = enrollmentRepository.findByUserIdOrderByCreatedAtDescIdDesc(userId, pageable);
 
-		if (enrollments.isEmpty()) {
-			return List.of();
+		if (enrollments.getContent().isEmpty()) {
+			return new PageImpl<>(List.of(), pageable, enrollments.getTotalElements());
 		}
 
-		List<Long> classIds = enrollments.stream().map(Enrollment::getClassId).distinct().toList();
+		List<Long> classIds = enrollments.getContent().stream().map(Enrollment::getClassId).distinct().toList();
 
 		Map<Long, Lecture> lectureById = lectureRepository.findAllById(classIds).stream()
 				.collect(Collectors.toMap(Lecture::getId, lecture -> lecture));
-			
-		return enrollments.stream()
-				.map(enrollment -> {
-					Lecture lecture = lectureById.get(enrollment.getClassId());
-					if (lecture == null) {
-						throw new BusinessException(ErrorCode.NOT_FOUND);
-					}
-					return new EnrollmentListItemResponse(
-							enrollment.getId(),
-							enrollment.getStatus(),
-							enrollment.getConfirmedAt(),
-							toListItem(lecture));
-				})
-				.toList();
+
+		return enrollments.map(enrollment -> {
+			Lecture lecture = lectureById.get(enrollment.getClassId());
+			if (lecture == null) {
+				throw new BusinessException(ErrorCode.NOT_FOUND);
+			}
+			return new EnrollmentListItemResponse(
+					enrollment.getId(),
+					enrollment.getStatus(),
+					enrollment.getConfirmedAt(),
+					toListItem(lecture));
+		});
 	}
 
 	@Transactional

--- a/src/main/java/io/github/jangdongho/productengineer/lecture/controller/ClassController.java
+++ b/src/main/java/io/github/jangdongho/productengineer/lecture/controller/ClassController.java
@@ -2,6 +2,7 @@ package io.github.jangdongho.productengineer.lecture.controller;
 
 import io.github.jangdongho.productengineer.common.api.ApiResponse;
 import io.github.jangdongho.productengineer.common.api.ErrorResponse;
+import io.github.jangdongho.productengineer.common.api.PageMeta;
 import io.github.jangdongho.productengineer.lecture.domain.ClassStatus;
 import io.github.jangdongho.productengineer.lecture.dto.ClassCreatedResponse;
 import io.github.jangdongho.productengineer.lecture.dto.ClassDetailResponse;
@@ -19,10 +20,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -42,9 +47,13 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Classes", description = "강의 생성, 조회, 상태 변경 API")
 public class ClassController {
 
+	private static final int DEFAULT_PAGE = 0;
+	private static final int DEFAULT_SIZE = 20;
+	private static final int MAX_SIZE = 100;
+
 	private final LectureService lectureService;
 
-	@Operation(summary = "강의 목록 조회", description = "강의 목록을 ID 오름차순으로 조회합니다. status를 전달하면 해당 모집 상태로 필터링합니다.")
+	@Operation(summary = "강의 목록 조회", description = "강의 목록을 생성일 최신순으로 페이지 조회합니다. status를 전달하면 해당 모집 상태로 필터링합니다.")
 	@ApiResponses({
 			@io.swagger.v3.oas.annotations.responses.ApiResponse(
 					responseCode = "200",
@@ -66,7 +75,15 @@ public class ClassController {
 									      "startDate": "2026-05-01T10:00:00",
 									      "endDate": "2026-05-30T18:00:00"
 									    }
-									  ]
+									  ],
+									  "meta": {
+									    "page": 0,
+									    "size": 20,
+									    "totalElements": 1,
+									    "totalPages": 1,
+									    "hasNext": false,
+									    "hasPrevious": false
+									  }
 									}
 									""")
 					)
@@ -80,8 +97,13 @@ public class ClassController {
 	@GetMapping
 	public ResponseEntity<ApiResponse<List<ClassListItemResponse>>> list(
 			@Parameter(description = "강의 모집 상태 필터", example = "OPEN")
-			@RequestParam(name = "status", required = false) ClassStatus status) {
-		return ResponseEntity.ok(ApiResponse.success(lectureService.listClasses(status)));
+			@RequestParam(name = "status", required = false) ClassStatus status,
+			@Parameter(description = "페이지 번호(0부터 시작)", example = "0")
+			@RequestParam(name = "page", defaultValue = "" + DEFAULT_PAGE) @PositiveOrZero int page,
+			@Parameter(description = "페이지 크기(1~100)", example = "20")
+			@RequestParam(name = "size", defaultValue = "" + DEFAULT_SIZE) @Positive @Max(MAX_SIZE) int size) {
+		Page<ClassListItemResponse> response = lectureService.listClasses(status, PageRequest.of(page, size));
+		return ResponseEntity.ok(ApiResponse.success(response.getContent(), PageMeta.from(response)));
 	}
 
 	@Operation(summary = "강의 상세 조회", description = "강의 ID로 상세 정보를 조회합니다.")
@@ -145,7 +167,15 @@ public class ClassController {
 									      "status": "CONFIRMED",
 									      "confirmedAt": "2026-05-01T12:00:00"
 									    }
-									  ]
+									  ],
+									  "meta": {
+									    "page": 0,
+									    "size": 20,
+									    "totalElements": 1,
+									    "totalPages": 1,
+									    "hasNext": false,
+									    "hasPrevious": false
+									  }
 									}
 									""")
 					)
@@ -171,9 +201,16 @@ public class ClassController {
 			@Parameter(description = "강의 ID", example = "1")
 			@PathVariable long id,
 			@Parameter(description = "강의 소유자(크리에이터) ID", example = "10", required = true)
-			@RequestParam("creatorId") @NotNull @Positive Long creatorId) {
-		return ResponseEntity.ok(
-				ApiResponse.success(lectureService.listConfirmedEnrollmentsForCreator(id, creatorId)));
+			@RequestParam("creatorId") @NotNull @Positive Long creatorId,
+			@Parameter(description = "페이지 번호(0부터 시작)", example = "0")
+			@RequestParam(name = "page", defaultValue = "" + DEFAULT_PAGE) @PositiveOrZero int page,
+			@Parameter(description = "페이지 크기(1~100)", example = "20")
+			@RequestParam(name = "size", defaultValue = "" + DEFAULT_SIZE) @Positive @Max(MAX_SIZE) int size) {
+		Page<ClassConfirmedEnrollmentItemResponse> response = lectureService.listConfirmedEnrollmentsForCreator(
+				id,
+				creatorId,
+				PageRequest.of(page, size));
+		return ResponseEntity.ok(ApiResponse.success(response.getContent(), PageMeta.from(response)));
 	}
 
 	@Operation(summary = "강의 생성", description = "크리에이터 ID와 강의 정보를 받아 강의를 DRAFT 상태로 생성합니다.")
@@ -206,7 +243,7 @@ public class ClassController {
 			@RequestParam("creatorId") @NotNull @Positive Long creatorId,
 			@Valid @RequestBody CreateClassRequest request) {
 		ClassCreatedResponse response = lectureService.create(creatorId, request);
-		
+
 		return ResponseEntity.status(HttpStatus.CREATED)
 				.body(ApiResponse.success(response));
 	}

--- a/src/main/java/io/github/jangdongho/productengineer/lecture/controller/ClassController.java
+++ b/src/main/java/io/github/jangdongho/productengineer/lecture/controller/ClassController.java
@@ -49,6 +49,7 @@ public class ClassController {
 
 	private static final int DEFAULT_PAGE = 0;
 	private static final int DEFAULT_SIZE = 20;
+	private static final int MAX_PAGE = 10_000;
 	private static final int MAX_SIZE = 100;
 
 	private final LectureService lectureService;
@@ -98,8 +99,8 @@ public class ClassController {
 	public ResponseEntity<ApiResponse<List<ClassListItemResponse>>> list(
 			@Parameter(description = "강의 모집 상태 필터", example = "OPEN")
 			@RequestParam(name = "status", required = false) ClassStatus status,
-			@Parameter(description = "페이지 번호(0부터 시작)", example = "0")
-			@RequestParam(name = "page", defaultValue = "" + DEFAULT_PAGE) @PositiveOrZero int page,
+			@Parameter(description = "페이지 번호(0~10000)", example = "0")
+			@RequestParam(name = "page", defaultValue = "" + DEFAULT_PAGE) @PositiveOrZero @Max(MAX_PAGE) int page,
 			@Parameter(description = "페이지 크기(1~100)", example = "20")
 			@RequestParam(name = "size", defaultValue = "" + DEFAULT_SIZE) @Positive @Max(MAX_SIZE) int size) {
 		Page<ClassListItemResponse> response = lectureService.listClasses(status, PageRequest.of(page, size));
@@ -202,8 +203,8 @@ public class ClassController {
 			@PathVariable long id,
 			@Parameter(description = "강의 소유자(크리에이터) ID", example = "10", required = true)
 			@RequestParam("creatorId") @NotNull @Positive Long creatorId,
-			@Parameter(description = "페이지 번호(0부터 시작)", example = "0")
-			@RequestParam(name = "page", defaultValue = "" + DEFAULT_PAGE) @PositiveOrZero int page,
+			@Parameter(description = "페이지 번호(0~10000)", example = "0")
+			@RequestParam(name = "page", defaultValue = "" + DEFAULT_PAGE) @PositiveOrZero @Max(MAX_PAGE) int page,
 			@Parameter(description = "페이지 크기(1~100)", example = "20")
 			@RequestParam(name = "size", defaultValue = "" + DEFAULT_SIZE) @Positive @Max(MAX_SIZE) int size) {
 		Page<ClassConfirmedEnrollmentItemResponse> response = lectureService.listConfirmedEnrollmentsForCreator(

--- a/src/main/java/io/github/jangdongho/productengineer/lecture/repository/LectureRepository.java
+++ b/src/main/java/io/github/jangdongho/productengineer/lecture/repository/LectureRepository.java
@@ -1,8 +1,9 @@
 package io.github.jangdongho.productengineer.lecture.repository;
 
 import jakarta.persistence.LockModeType;
-import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,9 +14,9 @@ import io.github.jangdongho.productengineer.lecture.domain.Lecture;
 
 public interface LectureRepository extends JpaRepository<Lecture, Long> {
 
-	List<Lecture> findAllByOrderByCreatedAtDesc();
+	Page<Lecture> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
-	List<Lecture> findByStatusOrderByCreatedAtDesc(ClassStatus status);
+	Page<Lecture> findByStatusOrderByCreatedAtDesc(ClassStatus status, Pageable pageable);
 
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("select lecture from Lecture lecture where lecture.id = :id")

--- a/src/main/java/io/github/jangdongho/productengineer/lecture/service/LectureService.java
+++ b/src/main/java/io/github/jangdongho/productengineer/lecture/service/LectureService.java
@@ -15,9 +15,10 @@ import io.github.jangdongho.productengineer.lecture.dto.ClassStatusResponse;
 import io.github.jangdongho.productengineer.lecture.dto.CreateClassRequest;
 import io.github.jangdongho.productengineer.lecture.repository.LectureRepository;
 
-import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,11 +31,11 @@ public class LectureService {
 	private final EnrollmentRepository enrollmentRepository;
 
 	@Transactional(readOnly = true)
-	public List<ClassListItemResponse> listClasses(@Nullable ClassStatus status) {
-		List<Lecture> lectures = status == null
-				? lectureRepository.findAllByOrderByCreatedAtDesc()
-				: lectureRepository.findByStatusOrderByCreatedAtDesc(status);
-		return lectures.stream().map(this::toListItem).toList();
+	public Page<ClassListItemResponse> listClasses(@Nullable ClassStatus status, Pageable pageable) {
+		Page<Lecture> lectures = status == null
+				? lectureRepository.findAllByOrderByCreatedAtDesc(pageable)
+				: lectureRepository.findByStatusOrderByCreatedAtDesc(status, pageable);
+		return lectures.map(this::toListItem);
 	}
 
 	@Transactional(readOnly = true)
@@ -45,19 +46,20 @@ public class LectureService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<ClassConfirmedEnrollmentItemResponse> listConfirmedEnrollmentsForCreator(long classId, long creatorId) {
+	public Page<ClassConfirmedEnrollmentItemResponse> listConfirmedEnrollmentsForCreator(
+			long classId,
+			long creatorId,
+			Pageable pageable) {
 		Lecture lecture = lectureRepository.findById(classId)
 				.orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
 
 		if (!Objects.equals(lecture.getCreatorId(), creatorId)) {
 			throw new BusinessException(ErrorCode.FORBIDDEN);
 		}
-		
+
 		return enrollmentRepository
-				.findByClassIdAndStatusOrderByCreatedAtDescIdDesc(classId, EnrollmentStatus.CONFIRMED)
-				.stream()
-				.map(this::toClassConfirmedItem)
-				.toList();
+				.findByClassIdAndStatusOrderByCreatedAtDescIdDesc(classId, EnrollmentStatus.CONFIRMED, pageable)
+				.map(this::toClassConfirmedItem);
 	}
 
 	@Transactional
@@ -75,7 +77,7 @@ public class LectureService {
 		lecture.setCurrentEnrollment(0);
 
 		lectureRepository.save(lecture);
-		
+
 		return new ClassCreatedResponse(lecture.getId());
 	}
 
@@ -83,7 +85,7 @@ public class LectureService {
 	public ClassStatusResponse updateStatus(long id, ClassStatus targetStatus) {
 		Lecture lecture = lectureRepository.findById(id)
 				.orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
-		
+
 		ClassStatus from = lecture.getStatus();
 
 		if (!isTransitionAllowed(from, targetStatus)) {

--- a/src/test/java/io/github/jangdongho/productengineer/enrollment/controller/EnrollmentControllerTest.java
+++ b/src/test/java/io/github/jangdongho/productengineer/enrollment/controller/EnrollmentControllerTest.java
@@ -26,6 +26,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -131,22 +133,35 @@ class EnrollmentControllerTest {
 	@Test
 	@DisplayName("GET /enrollments?userId= 는 성공 시 200 과 목록을 반환한다")
 	void list_returns200() throws Exception {
+		PageRequest pageable = PageRequest.of(1, 2);
 		ClassListItemResponse lecture = new ClassListItemResponse(
 				10L, 2L, "Spring Boot", ClassStatus.OPEN, 10_000L, 30,
 				LocalDateTime.parse("2026-05-01T10:00:00"), LocalDateTime.parse("2026-05-30T18:00:00"));
-		when(enrollmentService.listByUserId(1L))
-				.thenReturn(List.of(
-						new EnrollmentListItemResponse(5L, EnrollmentStatus.PENDING, null, lecture)));
+		when(enrollmentService.listByUserId(1L, pageable))
+				.thenReturn(new PageImpl<>(
+						List.of(new EnrollmentListItemResponse(5L, EnrollmentStatus.PENDING, null, lecture)),
+						pageable,
+						3));
 
-		mockMvc.perform(get("/enrollments").param("userId", "1"))
+		mockMvc.perform(get("/enrollments")
+						.param("userId", "1")
+						.param("page", "1")
+						.param("size", "2"))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.success", is(true)))
 				.andExpect(jsonPath("$.data[0].enrollmentId", is(5)))
 				.andExpect(jsonPath("$.data[0].status", is("PENDING")))
 				.andExpect(jsonPath("$.data[0].confirmedAt").doesNotExist())
 				.andExpect(jsonPath("$.data[0].lecture.id", is(10)))
-				.andExpect(jsonPath("$.data[0].lecture.title", is("Spring Boot")));
-		verify(enrollmentService).listByUserId(1L);
+				.andExpect(jsonPath("$.data[0].lecture.title", is("Spring Boot")))
+				.andExpect(jsonPath("$.meta.page", is(1)))
+				.andExpect(jsonPath("$.meta.size", is(2)))
+				.andExpect(jsonPath("$.meta.totalElements", is(3)))
+				.andExpect(jsonPath("$.meta.totalPages", is(2)))
+				.andExpect(jsonPath("$.meta.hasNext", is(false)))
+				.andExpect(jsonPath("$.meta.hasPrevious", is(true)))
+				.andExpect(jsonPath("$.meta.nextPage").doesNotExist());
+		verify(enrollmentService).listByUserId(1L, pageable);
 	}
 
 	@Test
@@ -166,9 +181,20 @@ class EnrollmentControllerTest {
 	}
 
 	@Test
+	@DisplayName("GET /enrollments 는 page 음수 또는 size 초과면 400 을 반환한다")
+	void list_invalidPagination_returns400() throws Exception {
+		mockMvc.perform(get("/enrollments")
+						.param("userId", "1")
+						.param("page", "-1")
+						.param("size", "101"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code", is(ErrorCode.VALIDATION_ERROR.getCode())));
+	}
+
+	@Test
 	@DisplayName("GET /enrollments?userId= 는 데이터 불일치 시 404 를 반환한다")
 	void list_lectureMissing_returns404() throws Exception {
-		when(enrollmentService.listByUserId(1L))
+		when(enrollmentService.listByUserId(1L, PageRequest.of(0, 20)))
 				.thenThrow(new BusinessException(ErrorCode.NOT_FOUND));
 
 		mockMvc.perform(get("/enrollments").param("userId", "1"))

--- a/src/test/java/io/github/jangdongho/productengineer/enrollment/controller/EnrollmentControllerTest.java
+++ b/src/test/java/io/github/jangdongho/productengineer/enrollment/controller/EnrollmentControllerTest.java
@@ -192,6 +192,17 @@ class EnrollmentControllerTest {
 	}
 
 	@Test
+	@DisplayName("GET /enrollments 는 page 가 상한(10000) 초과면 400 을 반환한다")
+	void list_pageExceedsMax_returns400() throws Exception {
+		mockMvc.perform(get("/enrollments")
+						.param("userId", "1")
+						.param("page", "10001")
+						.param("size", "20"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code", is(ErrorCode.VALIDATION_ERROR.getCode())));
+	}
+
+	@Test
 	@DisplayName("GET /enrollments?userId= 는 데이터 불일치 시 404 를 반환한다")
 	void list_lectureMissing_returns404() throws Exception {
 		when(enrollmentService.listByUserId(1L, PageRequest.of(0, 20)))

--- a/src/test/java/io/github/jangdongho/productengineer/enrollment/service/EnrollmentServiceTest.java
+++ b/src/test/java/io/github/jangdongho/productengineer/enrollment/service/EnrollmentServiceTest.java
@@ -36,6 +36,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 @ExtendWith(MockitoExtension.class)
 class EnrollmentServiceTest {
@@ -60,9 +63,11 @@ class EnrollmentServiceTest {
 	@Test
 	@DisplayName("listByUserId: 신청이 없으면 빈 목록")
 	void listByUserId_empty() {
-		when(enrollmentRepository.findByUserIdOrderByCreatedAtDescIdDesc(1L)).thenReturn(List.of());
+		PageRequest pageable = PageRequest.of(0, 20);
+		when(enrollmentRepository.findByUserIdOrderByCreatedAtDescIdDesc(1L, pageable))
+				.thenReturn(new PageImpl<>(List.of(), pageable, 0));
 
-		assertThat(enrollmentService.listByUserId(1L)).isEmpty();
+		assertThat(enrollmentService.listByUserId(1L, pageable).getContent()).isEmpty();
 
 		verify(lectureRepository, never()).findAllById(any());
 	}
@@ -70,15 +75,17 @@ class EnrollmentServiceTest {
 	@Test
 	@DisplayName("listByUserId: 신청·강의를 조합해 반환한다")
 	void listByUserId_mapsLecture() {
+		PageRequest pageable = PageRequest.of(0, 20);
 		Enrollment e1 = pendingEnrollment(10L, 1L, 20L);
 		Lecture lec = openLecture(20L, 30, 2);
-		when(enrollmentRepository.findByUserIdOrderByCreatedAtDescIdDesc(1L)).thenReturn(List.of(e1));
+		when(enrollmentRepository.findByUserIdOrderByCreatedAtDescIdDesc(1L, pageable))
+				.thenReturn(new PageImpl<>(List.of(e1), pageable, 1));
 		when(lectureRepository.findAllById(List.of(20L))).thenReturn(List.of(lec));
 
-		List<EnrollmentListItemResponse> result = enrollmentService.listByUserId(1L);
+		Page<EnrollmentListItemResponse> result = enrollmentService.listByUserId(1L, pageable);
 
-		assertThat(result).hasSize(1);
-		EnrollmentListItemResponse row = result.get(0);
+		assertThat(result.getContent()).hasSize(1);
+		EnrollmentListItemResponse row = result.getContent().getFirst();
 		assertThat(row.enrollmentId()).isEqualTo(10L);
 		assertThat(row.status()).isEqualTo(EnrollmentStatus.PENDING);
 		assertThat(row.confirmedAt()).isNull();
@@ -90,11 +97,13 @@ class EnrollmentServiceTest {
 	@Test
 	@DisplayName("listByUserId: 강의가 없으면 NOT_FOUND")
 	void listByUserId_lectureMissing() {
+		PageRequest pageable = PageRequest.of(0, 20);
 		Enrollment e1 = pendingEnrollment(1L, 1L, 99L);
-		when(enrollmentRepository.findByUserIdOrderByCreatedAtDescIdDesc(1L)).thenReturn(List.of(e1));
+		when(enrollmentRepository.findByUserIdOrderByCreatedAtDescIdDesc(1L, pageable))
+				.thenReturn(new PageImpl<>(List.of(e1), pageable, 1));
 		when(lectureRepository.findAllById(List.of(99L))).thenReturn(List.of());
 
-		assertThatThrownBy(() -> enrollmentService.listByUserId(1L))
+		assertThatThrownBy(() -> enrollmentService.listByUserId(1L, pageable))
 				.isInstanceOf(BusinessException.class)
 				.satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND));
 	}

--- a/src/test/java/io/github/jangdongho/productengineer/lecture/controller/ClassControllerTest.java
+++ b/src/test/java/io/github/jangdongho/productengineer/lecture/controller/ClassControllerTest.java
@@ -102,6 +102,16 @@ class ClassControllerTest {
 	}
 
 	@Test
+	@DisplayName("GET /classes 는 page 가 상한(10000) 초과면 400 을 반환한다")
+	void getList_pageExceedsMax_returns400() throws Exception {
+		mockMvc.perform(get("/classes")
+						.param("page", "10001")
+						.param("size", "20"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code", is(ErrorCode.VALIDATION_ERROR.getCode())));
+	}
+
+	@Test
 	@DisplayName("GET /classes/{id} 는 상세와 currentEnrollment 를 반환한다")
 	void getById_returnsDetail() throws Exception {
 		ClassDetailResponse body = new ClassDetailResponse(
@@ -205,6 +215,17 @@ class ClassControllerTest {
 						.param("creatorId", "1")
 						.param("page", "-1")
 						.param("size", "101"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code", is(ErrorCode.VALIDATION_ERROR.getCode())));
+	}
+
+	@Test
+	@DisplayName("GET /classes/{id}/enrollments 는 page 가 상한(10000) 초과면 400")
+	void getEnrollments_pageExceedsMax_returns400() throws Exception {
+		mockMvc.perform(get("/classes/1/enrollments")
+						.param("creatorId", "1")
+						.param("page", "10001")
+						.param("size", "20"))
 				.andExpect(status().isBadRequest())
 				.andExpect(jsonPath("$.code", is(ErrorCode.VALIDATION_ERROR.getCode())));
 	}

--- a/src/test/java/io/github/jangdongho/productengineer/lecture/controller/ClassControllerTest.java
+++ b/src/test/java/io/github/jangdongho/productengineer/lecture/controller/ClassControllerTest.java
@@ -31,6 +31,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -50,29 +52,53 @@ class ClassControllerTest {
 	@Test
 	@DisplayName("GET /classes 는 전체 목록을 반환한다")
 	void getList_all() throws Exception {
+		PageRequest pageable = PageRequest.of(0, 20);
 		ClassListItemResponse item = new ClassListItemResponse(
 				1L, 10L, "A", ClassStatus.DRAFT, 5_000L, 20,
 				LocalDateTime.parse("2026-05-01T10:00:00"), LocalDateTime.parse("2026-05-30T18:00:00"));
-		when(lectureService.listClasses(null)).thenReturn(List.of(item));
+		when(lectureService.listClasses(null, pageable))
+				.thenReturn(new PageImpl<>(List.of(item), pageable, 1));
 
 		mockMvc.perform(get("/classes"))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.success", is(true)))
 				.andExpect(jsonPath("$.data[0].id", is(1)))
-				.andExpect(jsonPath("$.data[0].title", is("A")));
+				.andExpect(jsonPath("$.data[0].title", is("A")))
+				.andExpect(jsonPath("$.meta.page", is(0)))
+				.andExpect(jsonPath("$.meta.size", is(20)))
+				.andExpect(jsonPath("$.meta.totalElements", is(1)))
+				.andExpect(jsonPath("$.meta.hasNext", is(false)));
 	}
 
 	@Test
 	@DisplayName("GET /classes?status=OPEN 는 필터된 목록을 반환한다")
 	void getList_withStatus() throws Exception {
+		PageRequest pageable = PageRequest.of(0, 5);
 		ClassListItemResponse item = new ClassListItemResponse(
 				2L, 1L, "B", ClassStatus.OPEN, 0L, 5,
 				LocalDateTime.parse("2026-06-01T09:00:00"), LocalDateTime.parse("2026-06-20T12:00:00"));
-		when(lectureService.listClasses(ClassStatus.OPEN)).thenReturn(List.of(item));
+		when(lectureService.listClasses(ClassStatus.OPEN, pageable))
+				.thenReturn(new PageImpl<>(List.of(item), pageable, 12));
 
-		mockMvc.perform(get("/classes").param("status", "OPEN"))
+		mockMvc.perform(get("/classes")
+						.param("status", "OPEN")
+						.param("page", "0")
+						.param("size", "5"))
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.data[0].status", is("OPEN")));
+				.andExpect(jsonPath("$.data[0].status", is("OPEN")))
+				.andExpect(jsonPath("$.meta.totalElements", is(12)))
+				.andExpect(jsonPath("$.meta.totalPages", is(3)))
+				.andExpect(jsonPath("$.meta.nextPage", is(1)));
+	}
+
+	@Test
+	@DisplayName("GET /classes 는 page 음수 또는 size 초과면 400 을 반환한다")
+	void getList_invalidPagination_returns400() throws Exception {
+		mockMvc.perform(get("/classes")
+						.param("page", "-1")
+						.param("size", "101"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code", is(ErrorCode.VALIDATION_ERROR.getCode())));
 	}
 
 	@Test
@@ -103,34 +129,41 @@ class ClassControllerTest {
 	@Test
 	@DisplayName("GET /classes/{id}/enrollments?creatorId= 는 소유자·확정 수강생을 반환한다")
 	void getEnrollments_confirmedList_returns200() throws Exception {
+		PageRequest pageable = PageRequest.of(0, 20);
 		ClassConfirmedEnrollmentItemResponse row = new ClassConfirmedEnrollmentItemResponse(
 				1L, 100L, EnrollmentStatus.CONFIRMED, LocalDateTime.parse("2026-05-01T12:00:00"));
-		when(lectureService.listConfirmedEnrollmentsForCreator(1L, 10L)).thenReturn(List.of(row));
+		when(lectureService.listConfirmedEnrollmentsForCreator(1L, 10L, pageable))
+				.thenReturn(new PageImpl<>(List.of(row), pageable, 1));
 
 		mockMvc.perform(get("/classes/1/enrollments").param("creatorId", "10"))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.success", is(true)))
 				.andExpect(jsonPath("$.data[0].enrollmentId", is(1)))
 				.andExpect(jsonPath("$.data[0].userId", is(100)))
-				.andExpect(jsonPath("$.data[0].status", is("CONFIRMED")));
-		verify(lectureService).listConfirmedEnrollmentsForCreator(1L, 10L);
+				.andExpect(jsonPath("$.data[0].status", is("CONFIRMED")))
+				.andExpect(jsonPath("$.meta.totalElements", is(1)));
+		verify(lectureService).listConfirmedEnrollmentsForCreator(1L, 10L, pageable);
 	}
 
 	@Test
 	@DisplayName("GET /classes/{id}/enrollments 는 확정 수강생 없을 때 200 빈 배열")
 	void getEnrollments_empty_returns200() throws Exception {
-		when(lectureService.listConfirmedEnrollmentsForCreator(2L, 1L)).thenReturn(List.of());
+		PageRequest pageable = PageRequest.of(0, 20);
+		when(lectureService.listConfirmedEnrollmentsForCreator(2L, 1L, pageable))
+				.thenReturn(new PageImpl<>(List.of(), pageable, 0));
 
 		mockMvc.perform(get("/classes/2/enrollments").param("creatorId", "1"))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.success", is(true)))
-				.andExpect(jsonPath("$.data.length()", is(0)));
+				.andExpect(jsonPath("$.data.length()", is(0)))
+				.andExpect(jsonPath("$.meta.totalElements", is(0)))
+				.andExpect(jsonPath("$.meta.totalPages", is(0)));
 	}
 
 	@Test
 	@DisplayName("GET /classes/{id}/enrollments 는 강의 없을 때 404")
 	void getEnrollments_notFound_returns404() throws Exception {
-		when(lectureService.listConfirmedEnrollmentsForCreator(99L, 1L))
+		when(lectureService.listConfirmedEnrollmentsForCreator(99L, 1L, PageRequest.of(0, 20)))
 				.thenThrow(new BusinessException(ErrorCode.NOT_FOUND));
 
 		mockMvc.perform(get("/classes/99/enrollments").param("creatorId", "1"))
@@ -141,7 +174,7 @@ class ClassControllerTest {
 	@Test
 	@DisplayName("GET /classes/{id}/enrollments 는 비소유자 403")
 	void getEnrollments_forbidden_returns403() throws Exception {
-		when(lectureService.listConfirmedEnrollmentsForCreator(1L, 2L))
+		when(lectureService.listConfirmedEnrollmentsForCreator(1L, 2L, PageRequest.of(0, 20)))
 				.thenThrow(new BusinessException(ErrorCode.FORBIDDEN));
 
 		mockMvc.perform(get("/classes/1/enrollments").param("creatorId", "2"))
@@ -161,6 +194,17 @@ class ClassControllerTest {
 	@DisplayName("GET /classes/{id}/enrollments 는 creatorId 가 음수면 400")
 	void getEnrollments_invalidCreatorId_returns400() throws Exception {
 		mockMvc.perform(get("/classes/1/enrollments").param("creatorId", "-1"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code", is(ErrorCode.VALIDATION_ERROR.getCode())));
+	}
+
+	@Test
+	@DisplayName("GET /classes/{id}/enrollments 는 page 음수 또는 size 초과면 400")
+	void getEnrollments_invalidPagination_returns400() throws Exception {
+		mockMvc.perform(get("/classes/1/enrollments")
+						.param("creatorId", "1")
+						.param("page", "-1")
+						.param("size", "101"))
 				.andExpect(status().isBadRequest())
 				.andExpect(jsonPath("$.code", is(ErrorCode.VALIDATION_ERROR.getCode())));
 	}

--- a/src/test/java/io/github/jangdongho/productengineer/lecture/service/LectureServiceTest.java
+++ b/src/test/java/io/github/jangdongho/productengineer/lecture/service/LectureServiceTest.java
@@ -30,6 +30,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 @ExtendWith(MockitoExtension.class)
 class LectureServiceTest {
@@ -46,30 +49,33 @@ class LectureServiceTest {
 	@Test
 	@DisplayName("listClasses: status 가 없으면 전체(createdAt 최신순)를 반환한다")
 	void listClasses_nullStatus_usesFindAll() {
+		PageRequest pageable = PageRequest.of(0, 20);
 		Lecture a = sampleLecture(1L, ClassStatus.DRAFT);
 		Lecture b = sampleLecture(2L, ClassStatus.OPEN);
-		when(lectureRepository.findAllByOrderByCreatedAtDesc()).thenReturn(List.of(b, a));
+		when(lectureRepository.findAllByOrderByCreatedAtDesc(pageable))
+				.thenReturn(new PageImpl<>(List.of(b, a), pageable, 2));
 
-		List<ClassListItemResponse> result = lectureService.listClasses(null);
+		Page<ClassListItemResponse> result = lectureService.listClasses(null, pageable);
 
-		assertThat(result).hasSize(2);
-		assertThat(result.getFirst().id()).isEqualTo(2L);
-		assertThat(result.get(1).id()).isEqualTo(1L);
-		verify(lectureRepository).findAllByOrderByCreatedAtDesc();
+		assertThat(result.getContent()).hasSize(2);
+		assertThat(result.getContent().getFirst().id()).isEqualTo(2L);
+		assertThat(result.getContent().get(1).id()).isEqualTo(1L);
+		verify(lectureRepository).findAllByOrderByCreatedAtDesc(pageable);
 	}
 
 	@Test
 	@DisplayName("listClasses: status 가 있으면 해당 상태만 반환한다")
 	void listClasses_withStatus_filters() {
+		PageRequest pageable = PageRequest.of(0, 20);
 		Lecture open = sampleLecture(1L, ClassStatus.OPEN);
-		when(lectureRepository.findByStatusOrderByCreatedAtDesc(ClassStatus.OPEN))
-				.thenReturn(List.of(open));
+		when(lectureRepository.findByStatusOrderByCreatedAtDesc(ClassStatus.OPEN, pageable))
+				.thenReturn(new PageImpl<>(List.of(open), pageable, 1));
 
-		List<ClassListItemResponse> result = lectureService.listClasses(ClassStatus.OPEN);
+		Page<ClassListItemResponse> result = lectureService.listClasses(ClassStatus.OPEN, pageable);
 
-		assertThat(result).hasSize(1);
-		assertThat(result.getFirst().status()).isEqualTo(ClassStatus.OPEN);
-		verify(lectureRepository).findByStatusOrderByCreatedAtDesc(ClassStatus.OPEN);
+		assertThat(result.getContent()).hasSize(1);
+		assertThat(result.getContent().getFirst().status()).isEqualTo(ClassStatus.OPEN);
+		verify(lectureRepository).findByStatusOrderByCreatedAtDesc(ClassStatus.OPEN, pageable);
 	}
 
 	@Test
@@ -162,9 +168,10 @@ class LectureServiceTest {
 	@Test
 	@DisplayName("listConfirmedEnrollmentsForCreator: 강의 없으면 NOT_FOUND, enrollmentRepository 미호출")
 	void listConfirmed_classNotFound() {
+		PageRequest pageable = PageRequest.of(0, 20);
 		when(lectureRepository.findById(99L)).thenReturn(Optional.empty());
 
-		assertThatThrownBy(() -> lectureService.listConfirmedEnrollmentsForCreator(99L, 1L))
+		assertThatThrownBy(() -> lectureService.listConfirmedEnrollmentsForCreator(99L, 1L, pageable))
 				.isInstanceOf(BusinessException.class)
 				.satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND));
 
@@ -174,11 +181,12 @@ class LectureServiceTest {
 	@Test
 	@DisplayName("listConfirmedEnrollmentsForCreator: 소유자 아님 FORBIDDEN, enrollmentRepository 미호출")
 	void listConfirmed_forbidden() {
+		PageRequest pageable = PageRequest.of(0, 20);
 		Lecture lecture = sampleLecture(1L, ClassStatus.OPEN);
 		lecture.setCreatorId(10L);
 		when(lectureRepository.findById(1L)).thenReturn(Optional.of(lecture));
 
-		assertThatThrownBy(() -> lectureService.listConfirmedEnrollmentsForCreator(1L, 99L))
+		assertThatThrownBy(() -> lectureService.listConfirmedEnrollmentsForCreator(1L, 99L, pageable))
 				.isInstanceOf(BusinessException.class)
 				.satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode()).isEqualTo(ErrorCode.FORBIDDEN));
 
@@ -188,20 +196,28 @@ class LectureServiceTest {
 	@Test
 	@DisplayName("listConfirmedEnrollmentsForCreator: 소유자·CONFIRMED 없으면 빈 목록")
 	void listConfirmed_empty() {
+		PageRequest pageable = PageRequest.of(0, 20);
 		Lecture lecture = sampleLecture(5L, ClassStatus.OPEN);
 		lecture.setCreatorId(2L);
 		when(lectureRepository.findById(5L)).thenReturn(Optional.of(lecture));
-		when(enrollmentRepository.findByClassIdAndStatusOrderByCreatedAtDescIdDesc(5L, EnrollmentStatus.CONFIRMED))
-				.thenReturn(List.of());
+		when(enrollmentRepository.findByClassIdAndStatusOrderByCreatedAtDescIdDesc(
+				5L,
+				EnrollmentStatus.CONFIRMED,
+				pageable))
+				.thenReturn(new PageImpl<>(List.of(), pageable, 0));
 
-		List<ClassConfirmedEnrollmentItemResponse> result = lectureService.listConfirmedEnrollmentsForCreator(5L, 2L);
+		Page<ClassConfirmedEnrollmentItemResponse> result = lectureService.listConfirmedEnrollmentsForCreator(
+				5L,
+				2L,
+				pageable);
 
-		assertThat(result).isEmpty();
+		assertThat(result.getContent()).isEmpty();
 	}
 
 	@Test
 	@DisplayName("listConfirmedEnrollmentsForCreator: CONFIRMED 항목을 DTO로 반환")
 	void listConfirmed_mapsRows() {
+		PageRequest pageable = PageRequest.of(0, 20);
 		Lecture lecture = sampleLecture(3L, ClassStatus.OPEN);
 		lecture.setCreatorId(7L);
 		Enrollment e = new Enrollment();
@@ -211,16 +227,22 @@ class LectureServiceTest {
 		e.setStatus(EnrollmentStatus.CONFIRMED);
 		e.setConfirmedAt(LocalDateTime.parse("2026-06-10T15:00:00"));
 		when(lectureRepository.findById(3L)).thenReturn(Optional.of(lecture));
-		when(enrollmentRepository.findByClassIdAndStatusOrderByCreatedAtDescIdDesc(3L, EnrollmentStatus.CONFIRMED))
-				.thenReturn(List.of(e));
+		when(enrollmentRepository.findByClassIdAndStatusOrderByCreatedAtDescIdDesc(
+				3L,
+				EnrollmentStatus.CONFIRMED,
+				pageable))
+				.thenReturn(new PageImpl<>(List.of(e), pageable, 1));
 
-		List<ClassConfirmedEnrollmentItemResponse> result = lectureService.listConfirmedEnrollmentsForCreator(3L, 7L);
+		Page<ClassConfirmedEnrollmentItemResponse> result = lectureService.listConfirmedEnrollmentsForCreator(
+				3L,
+				7L,
+				pageable);
 
-		assertThat(result).hasSize(1);
-		assertThat(result.getFirst().enrollmentId()).isEqualTo(100L);
-		assertThat(result.getFirst().userId()).isEqualTo(20L);
-		assertThat(result.getFirst().status()).isEqualTo(EnrollmentStatus.CONFIRMED);
-		assertThat(result.getFirst().confirmedAt()).isEqualTo(LocalDateTime.parse("2026-06-10T15:00:00"));
+		assertThat(result.getContent()).hasSize(1);
+		assertThat(result.getContent().getFirst().enrollmentId()).isEqualTo(100L);
+		assertThat(result.getContent().getFirst().userId()).isEqualTo(20L);
+		assertThat(result.getContent().getFirst().status()).isEqualTo(EnrollmentStatus.CONFIRMED);
+		assertThat(result.getContent().getFirst().confirmedAt()).isEqualTo(LocalDateTime.parse("2026-06-10T15:00:00"));
 	}
 
 	private static Lecture sampleLecture(long id, ClassStatus status) {


### PR DESCRIPTION
## 📌 개요

- 신청 내역, 강의 목록, 강의별 확정 수강생 목록 조회 API에 Offset 기반 페이지네이션을 적용했습니다.

## ✨ 작업 내용

- `page`, `size` Query Param을 통해 목록 API가 필요한 범위만 조회하도록 변경
- 페이지 응답에 `data`와 별도로 `meta`를 추가해 현재 페이지, 전체 건수, 전체 페이지, 다음/이전 페이지 여부를 제공
- 페이지 기본값은 `page=0`, `size=20`으로 설정하고 `size`는 최대 `100`까지 허용
- 내 수강 신청 목록, 강의 목록, 강의별 확정 수강생 목록의 컨트롤러/서비스/레포지토리 흐름을 `Page` 기반으로 변경
- README에 페이지네이션 Query Param과 응답 예시 문서화

## 🔥 변경 이유 (선택)

- 목록 데이터가 증가해도 응답 크기와 조회 비용을 제어할 수 있도록 페이지 단위 조회 구조를 도입했습니다.
- 클라이언트가 다음 페이지 존재 여부와 전체 건수를 함께 판단할 수 있도록 공통 메타데이터 응답 형식을 추가했습니다.

## 🧪 테스트

- [x] 정상 동작 확인
- [x] 예외 케이스 확인

## 🔗 관련 이슈

- close #21 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 모든 목록 조회 엔드포인트에 페이지네이션 지원 추가 (기본 페이지 크기: 20, 최대: 100)
  * API 응답에 현재 페이지, 전체 요소 수, 다음 페이지 여부 등의 페이지네이션 메타데이터 포함

* **문서**
  * API 스펙 업데이트로 페이지네이션 매개변수 및 응답 구조 명시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->